### PR TITLE
Added no-edit option for merging

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -389,12 +389,12 @@ no-ff!                 Never fast-forward during the merge
 
 	if noflag squash; then
 		if flag no_ff; then
-			git_do merge --no-ff "$BRANCH"
+			git_do merge --no-edit --no-ff "$BRANCH"
 		else
 			if [ "$(git rev-list -n2 "$BASE_BRANCH..$BRANCH" | wc -l)" -eq 1 ]; then
-				git_do merge --ff "$BRANCH"
+				git_do merge --no-edit --ff "$BRANCH"
 			else
-				git_do merge --no-ff "$BRANCH"
+				git_do merge --no-edit --no-ff "$BRANCH"
 			fi
 		fi
 	else


### PR DESCRIPTION
At time of merging feature branch to "develop", it is better to be more automated than prompting for a merge comment. This is ONLY for feature-flow